### PR TITLE
Delete MAINTAINERS file for LGTM.co service

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,4 +1,0 @@
-hkdobrev
-ivank
-dkyosev
-phgeorgiev


### PR DESCRIPTION
The LGTM.co service will fall back to the Maintainers team in the organisation.
See https://lgtm.co/docs/maintainers/

This is better than maintaining the MAINTAINERS file in all repos of the org.